### PR TITLE
Update to renamed tuya-vacuum API and bump minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Create a new [issue](https://github.com/jaidenlab/tuya-vacuum-maps/issues) to ad
 | Lebluelu SL60D | Supported |
 | Lebluelu SL68 | Supported |
 | Neatsvor X600 Pro | Supported |
+| KaBuM! Smart 700 / Liectroux XR500 | Supported |
 
 ## Development Environment
 

--- a/custom_components/tuya_vacuum_maps/camera.py
+++ b/custom_components/tuya_vacuum_maps/camera.py
@@ -73,7 +73,7 @@ class VacuumMapCamera(Camera):
         _LOGGER.debug("Updating image")
 
         vacuum = await self.hass.async_add_executor_job(
-            tuya_vacuum.TuyaVacuum,
+            tuya_vacuum.Vacuum,
             self._origin,
             self._client_id,
             self._client_secret,
@@ -81,7 +81,7 @@ class VacuumMapCamera(Camera):
         )
 
         # Fetch the realtime map
-        vacuum_map = vacuum.fetch_realtime_map()
+        vacuum_map = await self.hass.async_add_executor_job(vacuum.fetch_map)
 
         # Get the image
         image = vacuum_map.to_image()

--- a/custom_components/tuya_vacuum_maps/config_flow.py
+++ b/custom_components/tuya_vacuum_maps/config_flow.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, override
 
 import tuya_vacuum
-from tuya_vacuum.tuya import (
+from tuya_vacuum.errors import (
     CrossRegionAccessError,
     InvalidClientIDError,
     InvalidClientSecretError,
@@ -28,11 +28,11 @@ _LOGGER = logging.getLogger(__name__)
 async def validate_input(data: dict) -> None:
     """Validate that the user input allows us to connect."""
 
-    vacuum = tuya_vacuum.TuyaVacuum(
+    vacuum = tuya_vacuum.Vacuum(
         data["server"], data["client_id"], data["client_secret"], data["device_id"]
     )
 
-    vacuum.fetch_realtime_map()
+    vacuum.fetch_map()
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/tuya_vacuum_maps/manifest.json
+++ b/custom_components/tuya_vacuum_maps/manifest.json
@@ -11,7 +11,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/jaidenlabelle/tuya-vacuum-maps/issues",
     "requirements": [
-        "tuya-vacuum==0.1.8"
+        "tuya-vacuum>=0.1.9"
     ],
     "version": "0.1.4"
 }

--- a/scripts/download_maps.py
+++ b/scripts/download_maps.py
@@ -4,12 +4,13 @@ import os
 
 import requests
 from dotenv import load_dotenv
-from custom_components.tuya_vacuum_maps.tuya import TuyaCloudAPI
+from tuya_vacuum.tuya import TuyaCloudAPI
 
 # Load environment variables
 load_dotenv()
 
 # Get environment variables
+SERVER = os.environ.get("SERVER", "https://openapi.tuyaus.com")
 CLIENT_ID = os.environ["CLIENT_ID"]
 CLIENT_SECRET = os.environ["CLIENT_SECRET"]
 DEVICE_ID = os.environ["DEVICE_ID"]
@@ -18,11 +19,10 @@ DEVICE_ID = os.environ["DEVICE_ID"]
 def main():
     """Download the current realtime map from a vacuum using the Tuya Cloud API."""
 
-    BASE = "https://openapi.tuyaus.com"
-    ENDPOINT = f"/v1.0/users/sweepers/file/{DEVICE_ID}/realtime-map"
+    endpoint = f"/v1.0/users/sweepers/file/{DEVICE_ID}/realtime-map"
 
-    tuya = TuyaCloudAPI(base=BASE, client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
-    response = tuya.request(ENDPOINT)
+    tuya = TuyaCloudAPI(SERVER, CLIENT_ID, CLIENT_SECRET)
+    response = tuya.request("GET", endpoint)
 
     maps = response["result"]
 
@@ -31,18 +31,18 @@ def main():
 
         map_url = vacuum_map["map_url"]
         map_data = requests.get(map_url, timeout=2.5).content
+        map_type = vacuum_map["map_type"]
 
-        if vacuum_map["map_type"] == 1:
-            # Save Path Data
-            with open("path.bin", "wb") as file:
-                file.write(map_data)
-        if vacuum_map["map_type"] == 0:
-            # Save Map Data
-            with open("layout.bin", "wb") as file:
-                file.write(map_data)
+        if map_type == 1:
+            filename = "path.bin"
+        elif map_type == 0:
+            filename = "layout.bin"
         else:
-            # Unknown Map Type
-            print(f"Unknown Map Type: {vacuum_map['map_type']}")
+            filename = f"map_type_{map_type}.bin"
+            print(f"Unknown Map Type: {map_type}, saving raw data to {filename}")
+
+        with open(filename, "wb") as file:
+            file.write(map_data)
 
 
 if __name__ == "__main__":

--- a/scripts/parse_map_data.py
+++ b/scripts/parse_map_data.py
@@ -2,7 +2,9 @@
 
 import logging
 
-from custom_components.tuya_vacuum_maps.vacuum_map import VacuumMap
+from tuya_vacuum import Map
+from tuya_vacuum.map.layout import Layout
+from tuya_vacuum.map.path import Path
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -13,22 +15,11 @@ def main():
 
     with open("path.bin", "rb") as path_file:
         with open("layout.bin", "rb") as layout_file:
-            # Read each file as a hex string
-            layout_data = layout_file.read().hex()
-            path_data = path_file.read().hex()
+            layout = Layout(layout_file.read())
+            path = Path(path_file.read())
 
-            vacuum_map = VacuumMap(layout_data, path_data)
+            vacuum_map = Map(layout, path)
             map_image = vacuum_map.to_image()
-            map_image = VacuumMap.crop_image(
-                map_image,
-                410,
-                250,
-                vacuum_map.layout.origin_x,
-                vacuum_map.layout.origin_y,
-                offset_x=50,
-                offset_y=60,
-            )
-
             map_image.save("combined.png")
 
 


### PR DESCRIPTION
## Summary
- `tuya-vacuum`'s public API was renamed in a structure refactor (`TuyaVacuum` -> `Vacuum`, `fetch_realtime_map` -> `fetch_map`, exceptions moved from `tuya_vacuum.tuya` to `tuya_vacuum.errors`). The `requirements` pin here (`==0.1.8`) predates that refactor, so this bumps the minimum version and updates `config_flow.py`/`camera.py` accordingly. Also moves the blocking `fetch_map()` call in `camera.py` onto the executor, matching how the constructor is already dispatched.
- Fixes `scripts/download_maps.py` and `scripts/parse_map_data.py`, which imported a `custom_components.tuya_vacuum_maps.tuya`/`.vacuum_map` module that no longer exists - they now use the installed `tuya_vacuum` package directly. Also fixed an `if`/`if`/`else` bug in `download_maps.py` that misreported path map data (`map_type == 1`) as an unknown type, and made it save any unrecognized `map_type` for inspection instead of discarding it.
- Adds the KaBuM! Smart 700 / Liectroux XR500 to the compatibility list. Note: getting a working map on that device also needs the room-parsing fix in [jaidenlabelle/tuya-vacuum#8](https://github.com/jaidenlabelle/tuya-vacuum/pull/8), which isn't published to PyPI yet as of this PR.

## Test plan
- [x] `python3 -m py_compile` on all changed files.
- [x] Manually exercised the `config_flow.validate_input` code path end-to-end against a live device via the Tuya Cloud API.
- [x] Verified `camera.py`/`config_flow.py` against the new `tuya-vacuum` API surface (`Vacuum`, `fetch_map`, `tuya_vacuum.errors`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)